### PR TITLE
商品一覧ページの実装

### DIFF
--- a/app/assets/stylesheets/items/index.scss
+++ b/app/assets/stylesheets/items/index.scss
@@ -237,6 +237,10 @@ a {
   font-weight: bold;
 }
 
+ul {
+  list-style: none;
+}
+
 .item-lists {
   width: 100vw;
   display: flex;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
   def index
-    @items = Item.all
+    @items = Item.order('created_at DESC')
   end
 
   def new
@@ -15,6 +15,9 @@ class ItemsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
   end
 
   private

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,23 +125,29 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品',new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% if @items[0] != nil %>
+      <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-         <% @items.each do |item| %>
-           <%= image_tag item.image, class: "item-img" %>
+        <div class='item-img-content'> 
+        <%= link_to item_path(item.id) do %>
+         <%= image_tag item.image, class: "item-img" %>
            <div class='item-info'>
             <h3 class='item-name'>
               <%= item.name %>
             </h3>
             <div class='item-price'>
-             <%= "販売価格#{item.price}円" %>
-
+             <%= "#{item.price}円" %>
             </div>
-          </div>
+              <%= "#{item.payment.name}" %>
+           </div>
+         </div>
          <% end %>
+        </li>
+      <%end%>
+    <% else %>
+        <li class='list'>
+         <div class='item-img-content'>
+          <%= link_to "#" do %>
           <%= image_tag "item-sample.png", class: "item-img" %>
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -163,9 +169,6 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -181,10 +184,9 @@
             </div>
           </div>
         </div>
-        <% end %>
+      <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+    <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: "items#index"
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end


### PR DESCRIPTION
# What
商品一覧ページを作成した

# Why
投稿されたアイテムを一覧表示させる為


※商品購入機能実装前の為、sold outの表示は実装していません。

出品された日時が新しい順に表示
https://gyazo.com/d211af7c2d2bb9d395e26106324797ad

ログアウト状態でも一覧ページが表示される
https://gyazo.com/86c049594b0639ffe4967aaa64dacd53
